### PR TITLE
Allow "on" and "off" strings to be converted to Bool

### DIFF
--- a/Sources/String+Polymorphic.swift
+++ b/Sources/String+Polymorphic.swift
@@ -16,9 +16,9 @@ extension String: Polymorphic {
     */
     public var bool: Bool? {
         switch lowercased() {
-        case "y", "1", "yes", "t", "true":
+        case "y", "1", "yes", "t", "true", "on":
             return true
-        case "n", "0", "no", "f", "false":
+        case "n", "0", "no", "f", "false", "off":
             return false
         default:
             return nil

--- a/Tests/PolymorphicTests/PolymorphicTests.swift
+++ b/Tests/PolymorphicTests/PolymorphicTests.swift
@@ -60,6 +60,7 @@ class PolymorphicTests: XCTestCase {
         XCTAssert("t".bool == true)
         XCTAssert("true".bool == true)
         XCTAssert("1".bool == true)
+        XCTAssert("on".bool == true)
 
 
         XCTAssert("n".bool == false)
@@ -67,6 +68,7 @@ class PolymorphicTests: XCTestCase {
         XCTAssert("f".bool == false)
         XCTAssert("false".bool == false)
         XCTAssert("0".bool == false)
+        XCTAssert("off".bool == false)
 
         XCTAssert("nothing".bool == nil)
         XCTAssert("to".bool == nil)


### PR DESCRIPTION
An HTML form input declared as:

```html
<input type='checkbox' name='inputName' checked>
```

will come through to Vapor as:

```swift
["inputName": "on"]
```

so this PR allows Polymorphic to interpret this string as a Boolean `true`:

```swift
let result = request.data["inputName"]?.bool ?? false // will be true if checked, false if not
```

For completeness, `off` has been mapped to `false` though I don't think this is actually used; if a checkbox is not checked, no value comes through POST at all.